### PR TITLE
Added missing extra arguments for dump-autoload command

### DIFF
--- a/composer-sublime.sublime-settings
+++ b/composer-sublime.sublime-settings
@@ -30,6 +30,9 @@
     "composer_validate_extra" : ["-n", "-v"],
 
     // Extra arguments for composer require command
+    "composer_require_extra" : ["-n", "-v"],
+
+    // Extra arguments for composer dump-autoload command
     "composer_require_extra" : ["-n", "-v"]
 
 }

--- a/composer-sublime.sublime-settings
+++ b/composer-sublime.sublime-settings
@@ -33,6 +33,6 @@
     "composer_require_extra" : ["-n", "-v"],
 
     // Extra arguments for composer dump-autoload command
-    "composer_require_extra" : ["-n", "-v"]
+    "composer_dumpautoload_extra" : ["-n", "-v"]
 
 }


### PR DESCRIPTION
BaseComposerCommand.go() is expecting args to be an array ('join' in python.py:313)
